### PR TITLE
Include request in `ApiError`

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -86,12 +86,12 @@ final class Client implements AkismetClient
         $this->assertSubmissionBodyIsExpectedValue($response);
     }
 
-    public function assertSubmissionBodyIsExpectedValue(ResponseInterface $response): void
+    private function assertSubmissionBodyIsExpectedValue(RequestInterface $request, ResponseInterface $response): void
     {
         $expect = strtolower('Thanks for making the web a better place.');
         $body = strtolower((string) $response->getBody());
         if ($expect !== $body) {
-            throw ApiError::fromResponse($response);
+            throw ApiError::with($request, $response);
         }
     }
 

--- a/test/Unit/Exception/ApiErrorTest.php
+++ b/test/Unit/Exception/ApiErrorTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GSteel\Akismet\Test\Exception;
+
+use GSteel\Akismet\Exception\ApiError;
+use Laminas\Diactoros\Response\TextResponse;
+use Laminas\Diactoros\ServerRequestFactory;
+use PHPUnit\Framework\TestCase;
+
+class ApiErrorTest extends TestCase
+{
+    public function testThatTheRequestAndResponseAreEqualToThoseReceived(): void
+    {
+        $request = (new ServerRequestFactory())->createServerRequest('POST', '/foo');
+        $response = new TextResponse('Foo');
+
+        $error = ApiError::with($request, $response);
+
+        self::assertSame($request, $error->getRequest());
+        self::assertSame($response, $error->getResponse());
+    }
+
+    /**
+     * @return array<array-key, array{0: string}>
+     */
+    public function headerNameProvider(): array
+    {
+        return [
+            ['X-akismet-alert-msg'],
+            ['X-akismet-debug-help'],
+        ];
+    }
+
+    /** @dataProvider headerNameProvider */
+    public function testThatCustomAkismetHeaderValuesWillBePResentInTheErrorMessageIfSet(string $headerName): void
+    {
+        $request = (new ServerRequestFactory())->createServerRequest('POST', '/foo');
+        $response = (new TextResponse('Foo'))
+            ->withHeader($headerName, 'Goats');
+
+        $error = ApiError::with($request, $response);
+
+        self::assertStringContainsString('Goats', $error->getMessage());
+    }
+}


### PR DESCRIPTION
Changes the `ApiError` exception class so that it will always make the submitted request available.

Because of the signature changes to ApiError - this is effectively a BC break, but no one is using this library, and if anyone is using it, and they _are_ calling constructors on exception classes, well, they should know better.

Similarly, the method `Client::assertSubmissionBodyIsExpectedValue()` was mistakenly left public and is now private