### PR TITLE
Add Headers to Outbound Requests

### DIFF
--- a/src/AkismetClient.php
+++ b/src/AkismetClient.php
@@ -19,6 +19,8 @@ interface AkismetClient
     public const SUBMIT_SPAM_ACTION = 'submit-spam';
     /** @internal */
     public const SUBMIT_HAM_ACTION = 'submit-ham';
+    /** @internal */
+    public const USER_AGENT = 'gsteel/akismet PHP API Client/1.3.0';
 
     /**
      * Verify the configured, or the given Akismet key is usable with the given website address

--- a/src/Client.php
+++ b/src/Client.php
@@ -46,7 +46,7 @@ final class Client implements AkismetClient
 
     public function verifyKey(?string $apiKey = null, ?string $websiteUri = null): bool
     {
-        $request = $this->requestFactory->createRequest('POST', self::VERIFY_KEY_URI)
+        $request = $this->createRequest(self::VERIFY_KEY_URI)
             ->withBody($this->streamFactory->createStream(http_build_query([
                 'key' => $apiKey ?? $this->apiKey,
                 'blog' => $websiteUri ?? $this->websiteUri,
@@ -101,8 +101,15 @@ final class Client implements AkismetClient
 
     private function apiAction(CommentParameters $parameters, string $action): RequestInterface
     {
-        return $this->requestFactory->createRequest('POST', $this->action($action))
+        return $this->createRequest($this->action($action))
             ->withBody($this->streamFactory->createStream(http_build_query($parameters->toParameterList())));
+    }
+
+    private function createRequest(string $url): RequestInterface
+    {
+        return $this->requestFactory->createRequest('POST', $url)
+            ->withHeader('User-Agent', self::USER_AGENT)
+            ->withHeader('Content-Type', 'application/x-www-form-urlencoded');
     }
 
     private function sendRequest(RequestInterface $request): ResponseInterface

--- a/test/Unit/ClientTest.php
+++ b/test/Unit/ClientTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
+use function current;
 use function file_get_contents;
 use function urlencode;
 
@@ -83,6 +84,26 @@ class ClientTest extends TestCase
     public function testThatTheKeyVerificationRequestUsesTheGivenApiKey(RequestInterface $request): void
     {
         self::assertStringContainsString(urlencode('WHATEVER'), (string) $request->getBody());
+    }
+
+    /** @depends testThatVerifyingTheKeyIsSuccessfulWhenTheApiIndicatesItIsValid */
+    public function testTheRequestHasContentTypeHeader(RequestInterface $request): void
+    {
+        $header = $request->getHeader('Content-Type');
+        self::assertCount(1, $header);
+        $value = current($header);
+        self::assertIsString($value);
+        self::assertEquals('application/x-www-form-urlencoded', $value);
+    }
+
+    /** @depends testThatVerifyingTheKeyIsSuccessfulWhenTheApiIndicatesItIsValid */
+    public function testTheRequestHasANonEmptyUserAgentHeader(RequestInterface $request): void
+    {
+        $header = $request->getHeader('User-Agent');
+        self::assertCount(1, $header);
+        $value = current($header);
+        self::assertIsString($value);
+        self::assertNotEmpty($value);
     }
 
     public function testThatKeyVerificationArgumentsDefaultToTheConfiguredValues(): void


### PR DESCRIPTION
Adds `Content-Type` and `User-Agent` headers to all requests.

It would appear that with a `is_test=1` parameter, the remote API does not verify the content type header or the user-agent, but in practice, these are **required** in order for api requests to return non-error responses. And the error messages reveal zero about the actual problem.